### PR TITLE
Sort Overview Feeds By Number of Items

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -90,7 +90,7 @@ def overview(session: scoped_session) -> dict[str, Any]:
 
     items_by_feed = []
 
-    for feed, _ in feeds_with_max:
+    for feed, _, _ in feeds_with_max:
         recent_items = (
             session.query(Item)
             .filter(

--- a/logic.py
+++ b/logic.py
@@ -68,21 +68,23 @@ def overview(session: scoped_session) -> dict[str, Any]:
         days=OVERVIEW_NUM_DAYS_SINCE
     )
 
-    # Subquery to get the maximum published date for each feed
+    # Subquery to get the maximum published date and count of items for each feed
     subquery = (
         session.query(
-            Item.feed_id, sqlalchemy.func.max(Item.published).label("max_published")
+            Item.feed_id,
+            sqlalchemy.func.max(Item.published).label("max_published"),
+            sqlalchemy.func.count(Item.id).label("item_count")
         )
         .filter(Item.published >= since_date, Item.visited == False)
         .group_by(Item.feed_id)
         .subquery()
     )
 
-    # Query to fetch feeds that have items since `since_date`, along with their max published date
+    # Query to fetch feeds that have items since `since_date`, along with their max published date and item count
     feeds_with_max = (
-        session.query(Feed, subquery.c.max_published)
+        session.query(Feed, subquery.c.max_published, subquery.c.item_count)
         .join(subquery, Feed.id == subquery.c.feed_id)
-        .order_by(subquery.c.max_published.desc())
+        .order_by(subquery.c.max_published.desc(), subquery.c.item_count.asc())
         .all()
     )
 


### PR DESCRIPTION
In particular, put feeds with fewer items first, given the same date class. This effectively puts feeds that post less often before ones that post frequently. 