### PR TITLE
Add publish date to unvisited endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 instance/
 .aider*
 .env
+venv/

--- a/logic.py
+++ b/logic.py
@@ -234,3 +234,17 @@ def record_dismiss(session: scoped_session, item_id: int):
     if item:
         item.dismissed = datetime.datetime.now()
     session.commit()
+
+
+def unvisited_items_after(session: scoped_session, since_date: datetime.datetime):
+    """Return unvisited and not dismissed items newer than ``since_date``."""
+    return (
+        session.query(Item)
+        .filter(
+            Item.published >= since_date,
+            Item.visited == None,
+            Item.dismissed == None,
+        )
+        .order_by(Item.published.desc())
+        .all()
+    )

--- a/server.py
+++ b/server.py
@@ -1,7 +1,17 @@
 from urllib.parse import urlencode, urlunparse
-from flask import Flask, Request, abort, render_template, request, redirect, url_for
+from flask import (
+    Flask,
+    Request,
+    abort,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    jsonify,
+)
 from flask_sqlalchemy import SQLAlchemy
 import plotly.io
+import datetime
 
 from logic import (
     add_feed,
@@ -14,6 +24,7 @@ from logic import (
     toggle_feed_downrank,
     toggle_like,
     record_dismiss,
+    unvisited_items_after,
 )
 from stats_plot import plot_update_stats_figure
 from models import Base
@@ -115,6 +126,32 @@ def dismiss_item():
     return redirect(request.referrer or "/")
 
 
+@app.route("/api/unvisited")
+def api_unvisited_items():
+    """Return unvisited and not dismissed items newer than a given date."""
+    date_str = request.args.get("after")
+    if not date_str:
+        abort(400)
+    try:
+        since_date = datetime.datetime.fromisoformat(date_str)
+    except ValueError:
+        abort(400)
+
+    items = unvisited_items_after(db.session, since_date)
+
+    return jsonify(
+        [
+            {
+                "id": item.id,
+                "url": item.link,
+                "title": item.title,
+                "published": item.published.isoformat(),
+            }
+            for item in items
+        ]
+    )
+
+
 @app.route("/stats")
 def graph_update_stats():
     timeframe = request.args.get("window", default="week", type=str)
@@ -136,6 +173,7 @@ def go_to_item(item_id: int):
         abort(404)
     record_visit(db.session, item_id)
     return redirect(item.link)
+
 
 if __name__ == "__main__":
     app.run(debug=True)


### PR DESCRIPTION
## Summary
- ignore virtualenv directory
- move unvisited-item query into `logic.py`
- include publication date in `/api/unvisited` results

## Testing
- `black server.py logic.py models.py update.py`
- `python -m py_compile server.py logic.py models.py update.py`


------
https://chatgpt.com/codex/tasks/task_e_6841a91e4ad883288ca94049e1281529