### PR TITLE
Enable editing feed titles from manage page

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -180,6 +180,17 @@ def toggle_feed_downrank(session: scoped_session, id: int):
     session.commit()
 
 
+def update_feed_title(session: scoped_session, id: int, title: str | None) -> bool:
+    feed = session.query(Feed).get(id)
+    if feed is None:
+        return False
+
+    normalized = (title or "").strip()
+    feed.title = normalized or None
+    session.commit()
+    return True
+
+
 def feed_list(session: scoped_session):
     feeds = session.query(Feed).order_by(Feed.last_updated.desc()).all()
     return {"feeds": feeds}

--- a/server.py
+++ b/server.py
@@ -22,6 +22,7 @@ from logic import (
     feed_list,
     record_visit,
     toggle_feed_downrank,
+    update_feed_title,
     toggle_like,
     record_dismiss,
     unvisited_items_after,
@@ -88,6 +89,12 @@ def page_manage_feeds():
             delete_feed(db.session, int(request.form["delete"]))
         elif "downrank" in request.form:
             toggle_feed_downrank(db.session, int(request.form["downrank"]))
+        elif "feed_id" in request.form:
+            update_feed_title(
+                db.session,
+                int(request.form["feed_id"]),
+                request.form.get("title", ""),
+            )
         else:
             add_feed(db.session, request.form["url"])
         return redirect(url_for("page_manage_feeds"))

--- a/templates/feeds.html
+++ b/templates/feeds.html
@@ -28,14 +28,16 @@
         {% for feed in feeds %}
             <tr>
                 <td>
-                    <div class="feed-title-editor" style="display:flex; flex-direction:column; align-items:flex-start; gap:0.25rem;">
-                        <a href="/list?feed={{feed.id}}">{{ feed.title | default("Unknown", true) }}</a>
+                    <details class="feed-title-editor" style="display:flex; flex-direction:column; align-items:flex-start; gap:0.25rem;">
+                        <summary>
+                            <a href="/list?feed={{feed.id}}">{{ feed.title | default("Unknown", true) }}</a>
+                        </summary>
                         <form method="POST" class="edit-feed-title" style="display:flex; gap:0.25rem; align-items:center;">
                             <input type="hidden" name="feed_id" value="{{ feed.id }}">
                             <input type="text" name="title" value="{{ feed.title or '' }}" placeholder="Feed title" aria-label="Feed title">
                             <button type="submit">Save</button>
                         </form>
-                    </div>
+                    </details>
                 </td>
                 <td>
                     <a href="{{feed.url}}">{{ feed.url }}</a>

--- a/templates/feeds.html
+++ b/templates/feeds.html
@@ -28,7 +28,14 @@
         {% for feed in feeds %}
             <tr>
                 <td>
-                    <a href="/list?feed={{feed.id}}">{{ feed.title | default("Unknown", true) }}</a>
+                    <div class="feed-title-editor" style="display:flex; flex-direction:column; align-items:flex-start; gap:0.25rem;">
+                        <a href="/list?feed={{feed.id}}">{{ feed.title | default("Unknown", true) }}</a>
+                        <form method="POST" class="edit-feed-title" style="display:flex; gap:0.25rem; align-items:center;">
+                            <input type="hidden" name="feed_id" value="{{ feed.id }}">
+                            <input type="text" name="title" value="{{ feed.title or '' }}" placeholder="Feed title" aria-label="Feed title">
+                            <button type="submit">Save</button>
+                        </form>
+                    </div>
                 </td>
                 <td>
                     <a href="{{feed.url}}">{{ feed.url }}</a>

--- a/tests/test_feed_title.py
+++ b/tests/test_feed_title.py
@@ -1,0 +1,44 @@
+import os
+import unittest
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from models import Base, Feed
+
+os.makedirs("instance", exist_ok=True)
+
+from logic import update_feed_title
+
+
+class UpdateFeedTitleTests(unittest.TestCase):
+    def setUp(self):
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine)
+        self.session = Session()
+        feed = Feed(url="http://example.com", title="Original Title")
+        self.session.add(feed)
+        self.session.commit()
+        self.feed_id = feed.id
+        self.engine = engine
+
+    def tearDown(self):
+        self.session.close()
+        self.engine.dispose()
+
+    def test_updates_title_and_trims_whitespace(self):
+        update_feed_title(self.session, self.feed_id, "  Updated Title  ")
+        self.session.expire_all()
+        updated = self.session.query(Feed).get(self.feed_id)
+        self.assertEqual(updated.title, "Updated Title")
+
+    def test_blank_title_clears_value(self):
+        update_feed_title(self.session, self.feed_id, "   ")
+        self.session.expire_all()
+        updated = self.session.query(Feed).get(self.feed_id)
+        self.assertIsNone(updated.title)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a helper to update feed titles and handle the new form submission
- expose an inline edit form in the manage feeds table
- cover the title update behavior with unit tests

## Testing
- python -m unittest discover -s tests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6906c400c718832891a4b8b1f4afcbf4)