### PR TITLE
Add Terraform deployment for Cloud Run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ instance/
 .aider*
 .env
 venv/
+__pycache__/
+terraform/.terraform/
+terraform/.terraform.lock.hcl
+terraform/terraform.tfstate*

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 terraform/.terraform/
 terraform/.terraform.lock.hcl
 terraform/terraform.tfstate*
+terraform/terraform.tfvars

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim AS base
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV PORT=8080 \
+    RSRSSR_DB_PATH=/data/rss_feeds.db
+
+CMD ["gunicorn", "--bind", "0.0.0.0:8080", "server:app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 ENV PORT=8080 \
-    RSRSSR_DB_PATH=/data/rss_feeds.db
+    RSRSSR_DB_PATH=/tmp/rsrssr/rss_feeds.db
 
 CMD ["gunicorn", "--bind", "0.0.0.0:8080", "server:app"]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ RSRSSR only supports a single user, so there is no authentication/authorization 
 
 ## Data Storage
 
-The application uses SQLite to store data. The database includes tables for feeds, items, and update statistics. SQLAlchemy is used as the ORM to interact with the database. The database location can be overridden via the `RSRSSR_DB_PATH` environment variable (defaults to `instance/rss_feeds.db`).
+The application uses SQLite to store data. The database includes tables for feeds, items, and update statistics. SQLAlchemy is used as the ORM to interact with the database. The on-disk location can be overridden via the `RSRSSR_DB_PATH` environment variable (defaults to `instance/rss_feeds.db`), and Cloud deployments can mirror the file to Google Cloud Storage by pointing `RSRSSR_DB_GCS_URI` at a `gs://` object.
 
 ## Running the Server Locally
 
@@ -75,12 +75,19 @@ The application uses SQLite to store data. The database includes tables for feed
 
     The update script needs to be run periodically to fetch new items for all feeds. It shouldn't run more than once an hour, as each time it runs it will make a request for each feed. We do attempt to correctly implement caching to prevent unnecessary load on the feed servers.
 
+## Database Storage
+
+The application stores its state in a SQLite database. By default the file lives under `instance/rss_feeds.db`, but two environment variables control where the data is read from and how it is persisted:
+
+- `RSRSSR_DB_PATH` — Absolute path to the local SQLite file. In Cloud Run we keep the file inside `/tmp/rsrssr/rss_feeds.db` so all reads and writes happen on the container's in-memory filesystem.
+- `RSRSSR_DB_GCS_URI` — Optional `gs://bucket/object` URI. When set, the service downloads the database blob into `RSRSSR_DB_PATH` at startup and uploads it back to Cloud Storage whenever changes are committed (after each web request and when the update job completes). Uploads use the blob's generation number via `if_generation_match` so we never clobber a newer copy that was written by another process.
+
 ## Deploying on Google Cloud
 
 Terraform configuration is provided in the `terraform/` directory to deploy RSRSSR in a low-cost, serverless architecture:
 
-- **Cloud Run service** for the Flask web UI. A Cloud Storage bucket is mounted into the service via Cloud Storage FUSE so the SQLite database (`/data/rss_feeds.db`) is persisted in GCS.
-- **Cloud Run job** for `update.py`. It uses the same container image and bucket mount, and Cloud Scheduler triggers it every six hours (4× daily) via an authenticated HTTP call.
+- **Cloud Run service** for the Flask web UI. The container writes to `/tmp/rsrssr/rss_feeds.db` and uses the Cloud Storage JSON API (via `google-cloud-storage`) to pull/push the database blob with optimistic concurrency control.
+- **Cloud Run job** for `update.py`. It shares the same image and database sync logic, and Cloud Scheduler triggers it every six hours (4× daily) via an authenticated HTTP call.
 - **Artifact Registry** for storing container images and a dedicated service account with the minimal IAM roles required for Cloud Run, Cloud Scheduler, and bucket access.
 
 To deploy:
@@ -103,7 +110,7 @@ To deploy:
    terraform apply
    ```
 
-Terraform outputs the public Cloud Run URL and the name of the Cloud Storage bucket that stores the SQLite file. Because the bucket is mounted directly into both the web service and the update job, database changes made from the UI are immediately persisted to GCS, and the update job flushes new feed content after each run.
+Terraform outputs the public Cloud Run URL and the name of the Cloud Storage bucket that stores the SQLite file. Both the web service and the update job use the same object URI exposed via `RSRSSR_DB_GCS_URI`, so user actions and feed updates are mirrored back to Cloud Storage with generation checks to prevent overwriting concurrent writes.
 
 ## Source Code Overview
 

--- a/config.py
+++ b/config.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from functools import lru_cache
+from typing import Dict, Type
+
+from sqlalchemy.orm import Session as SQLASession
+
+from db_mirror import DatabaseMirror, build_mirrored_session_class
 
 _DEFAULT_DB_RELATIVE = Path("instance") / "rss_feeds.db"
 
@@ -20,12 +25,36 @@ def _resolve_db_path() -> Path:
 
 
 @lru_cache(maxsize=1)
+def _database_mirror() -> DatabaseMirror:
+    path = _resolve_db_path()
+    remote_uri = os.environ.get("RSRSSR_DB_GCS_URI")
+    mirror = DatabaseMirror(path, remote_uri)
+    mirror.ensure_local_copy()
+    return mirror
+
+
 def database_path() -> Path:
     """Return the absolute path to the SQLite database file."""
-    return _resolve_db_path()
+    return _database_mirror().local_path
 
 
 def database_uri() -> str:
     """Return a SQLAlchemy-compatible URI for the configured database."""
     path = database_path()
     return f"sqlite:///{path}"
+
+
+def database_mirror() -> DatabaseMirror:
+    return _database_mirror()
+
+
+_SESSION_CLASS_CACHE: Dict[Type[SQLASession], Type[SQLASession]] = {}
+
+
+def database_session_class(base: Type[SQLASession] | None = None) -> Type[SQLASession]:
+    base_cls = base or SQLASession
+    if base_cls not in _SESSION_CLASS_CACHE:
+        _SESSION_CLASS_CACHE[base_cls] = build_mirrored_session_class(
+            _database_mirror(), base_cls
+        )
+    return _SESSION_CLASS_CACHE[base_cls]

--- a/config.py
+++ b/config.py
@@ -1,0 +1,31 @@
+"""Runtime configuration helpers for RSRSSR."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from functools import lru_cache
+
+_DEFAULT_DB_RELATIVE = Path("instance") / "rss_feeds.db"
+
+
+def _resolve_db_path() -> Path:
+    raw_path = os.environ.get("RSRSSR_DB_PATH")
+    path = Path(raw_path) if raw_path else _DEFAULT_DB_RELATIVE
+    if not path.is_absolute():
+        path = Path.cwd() / path
+    parent = path.parent
+    if parent:
+        parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+@lru_cache(maxsize=1)
+def database_path() -> Path:
+    """Return the absolute path to the SQLite database file."""
+    return _resolve_db_path()
+
+
+def database_uri() -> str:
+    """Return a SQLAlchemy-compatible URI for the configured database."""
+    path = database_path()
+    return f"sqlite:///{path}"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+gcloud = "latest"
+terraform = "latest"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ gunicorn
 python-dateutil
 pandas
 plotly
+google-cloud-storage

--- a/server.py
+++ b/server.py
@@ -10,9 +10,11 @@ from flask import (
     jsonify,
 )
 from flask_sqlalchemy import SQLAlchemy
+from flask_sqlalchemy.session import Session as FlaskSession
 import plotly.io
 import datetime
-from config import database_uri
+from config import database_uri, database_session_class, database_mirror
+from db_mirror import StaleDatabaseError
 
 from logic import (
     add_feed,
@@ -35,15 +37,30 @@ from sqlalchemy import text
 
 app = Flask(__name__)
 app.config["SQLALCHEMY_DATABASE_URI"] = database_uri()
-db = SQLAlchemy(app)
+db = SQLAlchemy(app, session_options={"class_": database_session_class(FlaskSession)})
+mirror = database_mirror()
 
 with app.app_context():
+    snapshot = mirror.snapshot_local_state()
     Base.metadata.create_all(bind=db.engine)
+    mirror.mark_dirty_if_changed(snapshot)
     # Migrate: add dismissed column if it doesn't exist
     with db.engine.connect() as conn:
         existing = conn.execute(text("PRAGMA table_info('item')")).mappings().all()
         if not any(row["name"] == "dismissed" for row in existing):
             conn.execute(text("ALTER TABLE item ADD COLUMN dismissed DATETIME"))
+            mirror.mark_dirty()
+    mirror.sync_if_needed(reason="startup migrations")
+
+
+@app.after_request
+def sync_database(response):
+    try:
+        mirror.sync_if_needed(reason="request complete")
+    except StaleDatabaseError as exc:
+        app.logger.critical("Database sync failed: %s", exc)
+        raise
+    return response
 
 
 @app.template_filter("format_date")

--- a/server.py
+++ b/server.py
@@ -12,6 +12,7 @@ from flask import (
 from flask_sqlalchemy import SQLAlchemy
 import plotly.io
 import datetime
+from config import database_uri
 
 from logic import (
     add_feed,
@@ -33,7 +34,7 @@ from models import Item
 from sqlalchemy import text
 
 app = Flask(__name__)
-app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///rss_feeds.db"
+app.config["SQLALCHEMY_DATABASE_URI"] = database_uri()
 db = SQLAlchemy(app)
 
 with app.app_context():

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -124,18 +124,11 @@ resource "google_cloud_run_v2_service" "web" {
       }
       env {
         name  = "RSRSSR_DB_PATH"
-        value = "/data/rss_feeds.db"
+        value = "/tmp/rsrssr/rss_feeds.db"
       }
-      volume_mounts {
-        name       = "database"
-        mount_path = "/data"
-      }
-    }
-
-    volumes {
-      name = "database"
-      gcs {
-        bucket = google_storage_bucket.db.name
+      env {
+        name  = "RSRSSR_DB_GCS_URI"
+        value = "gs://${google_storage_bucket.db.name}/rss_feeds.db"
       }
     }
   }
@@ -173,24 +166,17 @@ resource "google_cloud_run_v2_job" "update" {
         command = ["python", "update.py"]
         env {
           name  = "RSRSSR_DB_PATH"
-          value = "/data/rss_feeds.db"
+          value = "/tmp/rsrssr/rss_feeds.db"
         }
-        volume_mounts {
-          name       = "database"
-          mount_path = "/data"
+        env {
+          name  = "RSRSSR_DB_GCS_URI"
+          value = "gs://${google_storage_bucket.db.name}/rss_feeds.db"
         }
         resources {
           limits = {
             cpu    = "1"
             memory = "512Mi"
           }
-        }
-      }
-
-      volumes {
-        name = "database"
-        gcs {
-          bucket = google_storage_bucket.db.name
         }
       }
     }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -202,7 +202,7 @@ resource "google_cloud_scheduler_job" "update" {
 
   http_target {
     http_method = "POST"
-    uri         = "https://${var.region}-run.googleapis.com/apis/run.googleapis.com/v1/${google_cloud_run_v2_job.update.name}:run"
+    uri         = "https://run.googleapis.com/v2/${google_cloud_run_v2_job.update.id}:run"
     body        = base64encode("{}")
 
     oauth_token {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,245 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.33"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+locals {
+  labels = merge({ app = "rsrssr" }, var.labels)
+  artifact_location = var.artifact_registry_location != "" ? var.artifact_registry_location : var.region
+}
+
+resource "google_project_service" "enabled" {
+  for_each = toset([
+    "artifactregistry.googleapis.com",
+    "cloudscheduler.googleapis.com",
+    "iam.googleapis.com",
+    "run.googleapis.com",
+    "storage.googleapis.com",
+  ])
+  project            = var.project_id
+  service            = each.value
+  disable_on_destroy = false
+}
+
+resource "google_storage_bucket" "db" {
+  name          = var.db_bucket_name != "" ? var.db_bucket_name : "${var.project_id}-rsrssr-db"
+  project       = var.project_id
+  location      = var.region
+  force_destroy = false
+
+  uniform_bucket_level_access = true
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+    condition {
+      num_newer_versions = 10
+    }
+  }
+
+  labels = local.labels
+}
+
+resource "google_service_account" "app" {
+  account_id   = "rsrssr-app"
+  display_name = "RSRSSR runtime"
+}
+
+resource "google_service_account" "scheduler" {
+  account_id   = "rsrssr-scheduler"
+  display_name = "RSRSSR Cloud Scheduler"
+}
+
+resource "google_storage_bucket_iam_member" "app" {
+  bucket = google_storage_bucket.db.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.app.email}"
+}
+
+resource "google_project_iam_member" "artifact_reader" {
+  project = var.project_id
+  role    = "roles/artifactregistry.reader"
+  member  = "serviceAccount:${google_service_account.app.email}"
+}
+
+resource "google_artifact_registry_repository" "app" {
+  location      = local.artifact_location
+  repository_id = var.artifact_registry_repo
+  format        = "DOCKER"
+  description   = "Container images for RSRSSR"
+  labels        = local.labels
+}
+
+locals {
+  container_image = var.container_image != "" ? var.container_image : "${local.artifact_location}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.app.repository_id}/rsrssr:latest"
+}
+
+resource "google_cloud_run_v2_service" "web" {
+  name     = var.service_name
+  location = var.region
+  labels   = local.labels
+
+  template {
+    service_account        = google_service_account.app.email
+    execution_environment  = "GEN2"
+    timeout                = "60s"
+
+    scaling {
+      min_instance_count = 0
+      max_instance_count = 1
+    }
+
+    containers {
+      image = local.container_image
+      ports {
+        container_port = 8080
+      }
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+      }
+      env {
+        name  = "PORT"
+        value = "8080"
+      }
+      env {
+        name  = "RSRSSR_DB_PATH"
+        value = "/data/rss_feeds.db"
+      }
+      volume_mounts {
+        name       = "database"
+        mount_path = "/data"
+      }
+    }
+
+    volumes {
+      name = "database"
+      gcs {
+        bucket = google_storage_bucket.db.name
+      }
+    }
+  }
+
+  ingress = "INGRESS_TRAFFIC_ALL"
+
+  depends_on = [google_project_service.enabled]
+}
+
+resource "google_cloud_run_v2_service_iam_member" "public" {
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_service.web.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+resource "google_cloud_run_v2_job" "update" {
+  name     = var.job_name
+  location = var.region
+  labels   = local.labels
+
+  template {
+    parallelism  = 1
+    task_count   = 1
+    template {
+      service_account       = google_service_account.app.email
+      execution_environment = "GEN2"
+      timeout               = "1200s"
+      max_retries           = 1
+
+      containers {
+        image   = local.container_image
+        command = ["python", "update.py"]
+        env {
+          name  = "RSRSSR_DB_PATH"
+          value = "/data/rss_feeds.db"
+        }
+        volume_mounts {
+          name       = "database"
+          mount_path = "/data"
+        }
+        resources {
+          limits = {
+            cpu    = "1"
+            memory = "512Mi"
+          }
+        }
+      }
+
+      volumes {
+        name = "database"
+        gcs {
+          bucket = google_storage_bucket.db.name
+        }
+      }
+    }
+  }
+
+  depends_on = [google_project_service.enabled]
+}
+
+resource "google_cloud_run_v2_job_iam_member" "scheduler" {
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_job.update.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.scheduler.email}"
+}
+
+resource "google_cloud_scheduler_job" "update" {
+  name        = "${var.job_name}-schedule"
+  description = "Trigger the RSRSSR update Cloud Run job"
+  schedule    = var.update_schedule
+  time_zone   = var.time_zone
+  region      = var.region
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://${var.region}-run.googleapis.com/apis/run.googleapis.com/v1/${google_cloud_run_v2_job.update.name}:run"
+    body        = base64encode("{}")
+
+    oauth_token {
+      service_account_email = google_service_account.scheduler.email
+    }
+
+    headers = {
+      "Content-Type" = "application/json"
+    }
+  }
+
+  depends_on = [
+    google_project_service.enabled,
+    google_cloud_run_v2_job_iam_member.scheduler,
+  ]
+}
+
+output "service_url" {
+  description = "Public URL for the RSRSSR web interface"
+  value       = google_cloud_run_v2_service.web.uri
+}
+
+output "database_bucket" {
+  description = "Bucket that stores the SQLite database"
+  value       = google_storage_bucket.db.name
+}
+
+output "artifact_repository" {
+  description = "Artifact Registry repository that should host the container image"
+  value       = google_artifact_registry_repository.app.id
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,6 @@
+project_id = "my-project-id"
+region     = "us-central1"
+
+# Optional overrides
+# container_image = "us-central1-docker.pkg.dev/my-project-id/rsrssr/rsrssr:latest"
+# db_bucket_name  = "my-custom-rsrssr-db"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,64 @@
+variable "project_id" {
+  description = "ID of the Google Cloud project"
+  type        = string
+}
+
+variable "region" {
+  description = "Region to deploy Cloud Run and Cloud Scheduler resources"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "artifact_registry_location" {
+  description = "Region/loc for Artifact Registry (defaults to region when empty)"
+  type        = string
+  default     = ""
+}
+
+variable "artifact_registry_repo" {
+  description = "Name of the Artifact Registry repository"
+  type        = string
+  default     = "rsrssr"
+}
+
+variable "container_image" {
+  description = "Fully qualified container image to deploy (defaults to repo-created path)"
+  type        = string
+  default     = ""
+}
+
+variable "service_name" {
+  description = "Name for the Cloud Run service"
+  type        = string
+  default     = "rsrssr-web"
+}
+
+variable "job_name" {
+  description = "Name for the Cloud Run job that runs update.py"
+  type        = string
+  default     = "rsrssr-update"
+}
+
+variable "db_bucket_name" {
+  description = "Optional override for the Cloud Storage bucket name"
+  type        = string
+  default     = ""
+}
+
+variable "update_schedule" {
+  description = "Cron schedule for Cloud Scheduler"
+  type        = string
+  default     = "0 */6 * * *"
+}
+
+variable "time_zone" {
+  description = "IANA time zone for the scheduler"
+  type        = string
+  default     = "Etc/UTC"
+}
+
+variable "labels" {
+  description = "Additional resource labels"
+  type        = map(string)
+  default     = {}
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/update.py
+++ b/update.py
@@ -8,19 +8,22 @@ from dateutil.relativedelta import relativedelta
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 from models import Base, Item, Feed, UpdateStat
-from config import database_uri
+from config import database_uri, database_session_class, database_mirror
 
 engine = create_engine(database_uri())
-
+mirror = database_mirror()
+snapshot = mirror.snapshot_local_state()
 Base.metadata.create_all(engine)
+mirror.mark_dirty_if_changed(snapshot)
 
 # Migrate: add dismissed column if it doesn't exist
 with engine.connect() as conn:
     existing = conn.execute(text("PRAGMA table_info('item')")).mappings().all()
     if not any(row["name"] == "dismissed" for row in existing):
         conn.execute(text("ALTER TABLE item ADD COLUMN dismissed DATETIME"))
+        mirror.mark_dirty()
 
-Session = sessionmaker(bind=engine)
+Session = sessionmaker(bind=engine, class_=database_session_class())
 
 
 def datetime_from_time(t):
@@ -187,4 +190,5 @@ if __name__ == "__main__":
     print(f"update took {stats.dur_total}s")
     session.add(stats)
     session.commit()
+    mirror.sync_if_needed(reason="update job complete")
     print("finished!")

--- a/update.py
+++ b/update.py
@@ -8,8 +8,9 @@ from dateutil.relativedelta import relativedelta
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 from models import Base, Item, Feed, UpdateStat
+from config import database_uri
 
-engine = create_engine("sqlite:///instance/rss_feeds.db")
+engine = create_engine(database_uri())
 
 Base.metadata.create_all(engine)
 


### PR DESCRIPTION
## Summary
- add a configurable database helper and Dockerfile so the app can run on Cloud Run with an externalized SQLite path
- describe a full Google Cloud deployment using Terraform, including Cloud Run services, Cloud Scheduler, and a GCS bucket for the database
- add CI-friendly pytest configuration and ignore Terraform state files

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a18b9eac48328863d973618b91842)